### PR TITLE
Update ResourceNavigationTab.php

### DIFF
--- a/src/ResourceNavigationTab.php
+++ b/src/ResourceNavigationTab.php
@@ -149,7 +149,7 @@ class ResourceNavigationTab extends Panel
      *
      * @return string
      */
-    public function getTableLabel(NovaRequest $request): string
+    public function getTableLabel(NovaRequest $request): ?string
     {
         return $this->configuration[ 'label' ];
     }


### PR DESCRIPTION
Fix exception:

```json
{
    "message": "Return value of DigitalCreative\\ResourceNavigationTab\\ResourceNavigationTab::getTableLabel() must be of the type string, null returned",
    "exception": "Symfony\\Component\\Debug\\Exception\\FatalThrowableError",
    "file": "/var/www/app/vendor/digital-creative/resource-navigation-tab/src/ResourceNavigationTab.php",
    "line": 154,
    "trace": [
        {
            "file": "/var/www/app/vendor/digital-creative/resource-navigation-tab/src/ResourceNavigationTab.php",
            "line": 64,
            "function": "getTableLabel",
            "class": "DigitalCreative\\ResourceNavigationTab\\ResourceNavigationTab",
            "type": "->"
        },
        {
            "file": "/var/www/app/vendor/digital-creative/resource-navigation-tab/src/ResourceNavigationTab.php",
            "line": 134,
            "function": "__construct",
            "class": "DigitalCreative\\ResourceNavigationTab\\ResourceNavigationTab",
            "type": "->"
        },
```